### PR TITLE
Add support for UK and Australian Transcription

### DIFF
--- a/lib/voicebase/version.rb
+++ b/lib/voicebase/version.rb
@@ -1,5 +1,5 @@
 module VoiceBase
-  VERSION = "1.1.1"
+  VERSION = "1.2.0"
 
   def self.version; VERSION; end
 end

--- a/spec/lib/voicebase/v2/client_spec.rb
+++ b/spec/lib/voicebase/v2/client_spec.rb
@@ -66,16 +66,26 @@ describe VoiceBase::V2::Client do
     end
 
     context "#upload_media" do
-      it "makes an API call to VoiceBase to post the media file" do
-        url = "https://apis.voicebase.com/v2-beta/media"
+      let(:url) { "https://apis.voicebase.com/v2-beta/media" }
+      let(:media_url) { "http://s3.com/video.mp4" }
+
+      before do
         @request_headers.merge!({"Content-Type" => "multipart/form-data; boundary=0123456789ABLEWASIEREISAWELBA9876543210"})
-        media_url = "http://s3.com/video.mp4"
         allow(client).to receive(:require_media_file_or_url).and_return(media_url)
+      end
+
+      it "makes an API call to VoiceBase to post the media file" do
         body = "--0123456789ABLEWASIEREISAWELBA9876543210\r\nContent-Disposition: form-data; name=\"media\"\r\n\r\nhttp://s3.com/video.mp4\r\n--0123456789ABLEWASIEREISAWELBA9876543210\r\nContent-Disposition: form-data; name=\"configuration\"\r\n\r\n{\"configuration\":{\"executor\":\"v2\"}}\r\n--0123456789ABLEWASIEREISAWELBA9876543210--"
         httparty_options.merge!({body: body})
-
         expect(VoiceBase::Client).to receive(:post).with(url, httparty_options).and_return(http_response)
         client.upload_media({}, {})
+      end
+
+      it "adds the engine language code if specified" do
+        body = "--0123456789ABLEWASIEREISAWELBA9876543210\r\nContent-Disposition: form-data; name=\"media\"\r\n\r\nhttp://s3.com/video.mp4\r\n--0123456789ABLEWASIEREISAWELBA9876543210\r\nContent-Disposition: form-data; name=\"configuration\"\r\n\r\n{\"configuration\":{\"executor\":\"v2\",\"language\":\"en-UK\"}}\r\n--0123456789ABLEWASIEREISAWELBA9876543210--"
+        httparty_options.merge!({body: body})
+        expect(VoiceBase::Client).to receive(:post).with(url, httparty_options).and_return(http_response)
+        client.upload_media({language: 'en-UK'}, {})
       end
     end
 


### PR DESCRIPTION
#### Purpose

In an effort to improve transcript quality, set the engine to UK or Australian english language recognition.

#### Trello Card

https://trello.com/c/IT5vcG5v/2586-5-transcript-quality-apply-uk-and-aus-transcription-for-matching-users

