### PR TITLE
No configuration passed through on v2

### DIFF
--- a/lib/voicebase/v2/client.rb
+++ b/lib/voicebase/v2/client.rb
@@ -29,6 +29,7 @@ module VoiceBase
         media_url = require_media_file_or_url(args)
         form_args = form_args(media_url, args[:language]) # language codes: en-US (default), en-UK, en-AU
         form_args.merge! metadata(args[:external_id]) if args[:external_id]
+        form_args['configuration']['configuration'].merge! args[:configuration] if args[:configuration]
 
         response = self.class.post(
             uri + '/media',


### PR DESCRIPTION
The configuration defined in the 'upload_media' call doesn't merge in any configuration changes, so the dual-channel ingestion isn't possible, callbacks wouldn't be sent.