### PR TITLE
Allow bearer token supplied via env

### DIFF
--- a/lib/voicebase/client.rb
+++ b/lib/voicebase/client.rb
@@ -26,6 +26,10 @@ module VoiceBase
       @user_agent          = args[:user_agent] || "usertesting-client/#{VoiceBase::version}"
       @locale              = args[:locale] || 'en'  # US English
 
+      if ENV['VOICEBASE_BEARER_TOKEN']
+        @token = VoiceBase::Client::Token.new(ENV['VOICEBASE_BEARER_TOKEN'])
+      end
+
       if @api_version.to_f < 2.0
         self.extend(VoiceBase::V1::Client)
       else

--- a/lib/voicebase/version.rb
+++ b/lib/voicebase/version.rb
@@ -1,5 +1,5 @@
 module VoiceBase
-  VERSION = "1.2.3"
+  VERSION = "1.2.4"
 
   def self.version; VERSION; end
 end

--- a/spec/lib/voicebase/v2/client_spec.rb
+++ b/spec/lib/voicebase/v2/client_spec.rb
@@ -19,8 +19,20 @@ describe VoiceBase::V2::Client do
 
   let(:auth_token) { "My-Auth-Token" }
 
-  before do
-    client.token = double("voicebase token", token: auth_token)
+  context "with a supplied bearer token" do
+    let(:fake_token) { "abcdabcd1234234123" }
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("VOICEBASE_BEARER_TOKEN").and_return(fake_token)
+    end
+
+    describe "#authenticate!" do
+      it "already has a bearer token set" do
+        expect(client.token).to be_a(VoiceBase::Client::Token)
+        expect(client.token.token).to eq(fake_token)
+      end
+    end
   end
 
   context "pre-authentication" do
@@ -49,6 +61,8 @@ describe VoiceBase::V2::Client do
   end
 
   context "post-authentication" do
+    before { client.token = double("voicebase token", token: auth_token) }
+
     let(:media_id) { "some-media-id" }
     let(:voicebase_args) { {
         media_id: media_id


### PR DESCRIPTION
If `ENV['VOICEBASE_BEARER_TOKEN']` is set, then just use that token instead of requesting a new one.