### PR TITLE
Publish gem in new org/register

### DIFF
--- a/.github/workflows/publish_gem.yml
+++ b/.github/workflows/publish_gem.yml
@@ -1,0 +1,29 @@
+name: Publish Gem
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-ruby@v1
+    - name: Publish to Github
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:github: Bearer ${GH_PACKAGES_TEMP_TOKEN}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push --verbose --key github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+      env:
+        GH_PACKAGES_TEMP_TOKEN: ${{ secrets.GH_PACKAGES_TEMP_TOKEN }}
+        OWNER: "UserTestingEnterprise"
+      continue-on-error: true


### PR DESCRIPTION
# Purpose
We want to migrate this gem is from Gemfury to Github packages

# Implementation
Add a GitHub workflow to publish to a new org and registery

# Demo
https://github.com/orgs/UserTestingEnterprise/packages/rubygems/package/voicebase-client-ruby

# Notifications
@jthom-ut 
@rbellido-ut 